### PR TITLE
Update Brightcove and VideoJS (contrib DASH) Players

### DIFF
--- a/bc-player.html
+++ b/bc-player.html
@@ -48,11 +48,9 @@
     </div>
 
     <div class="jumbotron">
-      <!-- <video id="example" width="600" height="300" data&#45;account="4276901753001" data&#45;player="edae5cc2&#45;925e&#45;4679&#45;9984&#45;89f75c7ddc31" data&#45;embed="default" class="video&#45;js vjs&#45;default&#45;skin center&#45;block" controls></video> -->
-      <!-- <script src="//players.brightcove.net/4276901753001/edae5cc2&#45;925e&#45;4679&#45;9984&#45;89f75c7ddc31_default/index.min.js"></script> -->
-
-      <video id="example" data-account="5270290590001" data-player="BJszhI6rx" data-embed="default" data-application-id class="video-js center-block" controls width="600" height="300"></video>
+      <video id="example" data-account="5270290590001" data-player="BJszhI6rx" data-embed="default" data-application-id class="video-js vjs-default-skin center-block" controls width="600" height="300"></video>
       <script src="//players.brightcove.net/5270290590001/BJszhI6rx_default/index.min.js"></script>
+
       <!-- BC Player Debugger styles and script -->
       <link href="https://solutions.brightcove.com/marguin/debugger/css/brightcove-player-debugger.css" rel="stylesheet">
       <script src="https://solutions.brightcove.com/marguin/debugger/js/brightcove-player-debugger.min.js"></script>
@@ -63,7 +61,8 @@
       <p><small>This should play CENC content everywhere, using the Brightcove special sauce for setting license URLs, <a href="http://docs.brightcove.com/en/video-cloud/brightcove-player/guides/dash-drm.html">as documented here.</a></small></p>
     </div>
 
-    <script>
+    <script type='text/javascript'>
+
     var player = videojs('example');
     options = {
       "verbose": true,
@@ -75,7 +74,7 @@
       "debugAds": true,
     };
     player.playerDebugger(options);
-    // player.dash.mediaPlayer.getDebug().setLogToBrowserConsole(true);
+
     $( "#playform" ).submit(function( event ) {
       var licenseUrl = $( "#license" ).val();
       var manifestUrl = $( "#manifest" ).val();

--- a/bc-player.html
+++ b/bc-player.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>Stuart's Players - Brightcove Player</title>
+  <title>Phil's Players - Brightcove Player</title>
 
   <!-- Bootstrap -->
   <link href="css/bootstrap.min.css" rel="stylesheet">
@@ -29,7 +29,7 @@
           <li role="presentation"><a href="#">Contact</a></li>
         </ul>
       </nav>
-      <h3 class="text-muted">Stuart's Players</h3>
+      <h3 class="text-muted">Phil's Players</h3>
     </div>
 
     <div class="jumbotron">
@@ -116,7 +116,7 @@
     </script>
 
     <footer class="footer">
-      <p>&copy; Stuart Hicks and Phil Cluff 2016</p>
+      <p>&copy; Phil Cluff 2016</p>
     </footer>
 
   </div>

--- a/bc-player.html
+++ b/bc-player.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>Phil's Players - Brightcove Player</title>
+  <title>Stuart's Players - Brightcove Player</title>
 
   <!-- Bootstrap -->
   <link href="css/bootstrap.min.css" rel="stylesheet">
@@ -29,7 +29,7 @@
           <li role="presentation"><a href="#">Contact</a></li>
         </ul>
       </nav>
-      <h3 class="text-muted">Phil's Players</h3>
+      <h3 class="text-muted">Stuart's Players</h3>
     </div>
 
     <div class="jumbotron">
@@ -38,14 +38,24 @@
           <label for="manifest">MPEG DASH Manifest:</label>
           <input type="text" class="form-control" id="manifest" name="manifest">
         </div>
+        <div class="form-group">
+          <label for="license">Widevine License Server: <small>(Optional)</small></label>
+          <input type="text" class="form-control" id="license" name="license">
+        </div>
         <button type="submit" class="btn btn-primary btn-lg">Play!</button><br><br>
         <button type="button" id="demo" class="btn btn-info btn-sm">Load Demo Manifest</button>
       </form>
     </div>
 
     <div class="jumbotron">
-      <video id="example" width="600" height="300" data-account="4276901753001" data-player="edae5cc2-925e-4679-9984-89f75c7ddc31" data-embed="default" class="video-js vjs-default-skin center-block" controls></video>
-      <script src="//players.brightcove.net/4276901753001/edae5cc2-925e-4679-9984-89f75c7ddc31_default/index.min.js"></script>
+      <!-- <video id="example" width="600" height="300" data&#45;account="4276901753001" data&#45;player="edae5cc2&#45;925e&#45;4679&#45;9984&#45;89f75c7ddc31" data&#45;embed="default" class="video&#45;js vjs&#45;default&#45;skin center&#45;block" controls></video> -->
+      <!-- <script src="//players.brightcove.net/4276901753001/edae5cc2&#45;925e&#45;4679&#45;9984&#45;89f75c7ddc31_default/index.min.js"></script> -->
+
+      <video id="example" data-account="5270290590001" data-player="BJszhI6rx" data-embed="default" data-application-id class="video-js center-block" controls width="600" height="300"></video>
+      <script src="//players.brightcove.net/5270290590001/BJszhI6rx_default/index.min.js"></script>
+      <!-- BC Player Debugger styles and script -->
+      <link href="https://solutions.brightcove.com/marguin/debugger/css/brightcove-player-debugger.css" rel="stylesheet">
+      <script src="https://solutions.brightcove.com/marguin/debugger/js/brightcove-player-debugger.min.js"></script>
     </div>
 
     <div class="jumbotron">
@@ -55,12 +65,45 @@
 
     <script>
     var player = videojs('example');
+    options = {
+      "verbose": true,
+      "logClasses": true,
+      "useLineNums": true,
+      "showProgress": true,
+      "showMediaInfo": true,
+      "captureConsole": true,
+      "debugAds": true,
+    };
+    player.playerDebugger(options);
+    // player.dash.mediaPlayer.getDebug().setLogToBrowserConsole(true);
     $( "#playform" ).submit(function( event ) {
+      var licenseUrl = $( "#license" ).val();
+      var manifestUrl = $( "#manifest" ).val();
 
-      player.src({
-        src: $( "#manifest" ).val(),
-        type: 'application/dash+xml'
-      });
+      // With Widevine
+      if (licenseUrl !== "") {
+        console.log('Will do DRM');
+        player.src({
+          src: manifestUrl,
+          type: 'application/dash+xml',
+          keySystemOptions: [
+            {
+              name: 'com.widevine.alpha',
+              options: {
+                licenseUrl: licenseUrl
+              }
+            }
+          ]
+        });
+      }
+      // No DRM
+      else {
+        console.log('Will NOT do DRM');
+        player.src({
+          src: manifestUrl,
+          type: 'application/dash+xml'
+        });
+      }
 
       player.play();
       event.preventDefault();
@@ -73,7 +116,7 @@
     </script>
 
     <footer class="footer">
-      <p>&copy; Phil Cluff 2016</p>
+      <p>&copy; Stuart Hicks and Phil Cluff 2016</p>
     </footer>
 
   </div>

--- a/bc-player.html
+++ b/bc-player.html
@@ -58,7 +58,7 @@
 
     <div class="jumbotron">
       <p>This player is The Brightcove Player with all DRM enabled.<br><a href="https://www.brightcove.com/en/online-video-platform/video-player">More details can be found here.</a></p>
-      <p><small>This should play CENC content everywhere, using the Brightcove special sauce for setting license URLs, <a href="http://docs.brightcove.com/en/video-cloud/brightcove-player/guides/dash-drm.html">as documented here.</a></small></p>
+      <p><small>This should play CENC content everywhere. Full DRM documentation for this player can be found <a href="http://docs.brightcove.com/en/video-cloud/brightcove-player/guides/dash-drm.html">here</a>.</small></p>
     </div>
 
     <script type='text/javascript'>

--- a/videojs-contrib-dash.html
+++ b/videojs-contrib-dash.html
@@ -57,7 +57,7 @@
 
     <div class="jumbotron">
       <p>This player is VideoJS with Contrib Dash (DashJS)<br><a href="http://videojs.github.io/videojs-contrib-dash/">More details can be found here.</a></p>
-      <p><small>VideoJS 5.9 ~ DashJS 1.2.0 ~ VideoJS Contrib Dash 2.4.0</small></p>
+      <p><small>VideoJS 5.9 ~ DashJS 2.4.0 ~ VideoJS Contrib Dash 2.4.0</small></p>
     </div>
 
     <script>

--- a/videojs-contrib-dash.html
+++ b/videojs-contrib-dash.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>Stuart's Players - VideoJS with Contrib Dash (DashJS)</title>
+  <title>Phil's Players - VideoJS with Contrib Dash (DashJS)</title>
 
   <!-- Bootstrap -->
   <link href="css/bootstrap.min.css" rel="stylesheet">
@@ -33,7 +33,7 @@
           <li role="presentation"><a href="#">Contact</a></li>
         </ul>
       </nav>
-      <h3 class="text-muted">Stuart's Players</h3>
+      <h3 class="text-muted">Phil's Players</h3>
     </div>
 
     <div class="jumbotron">
@@ -103,7 +103,7 @@
     </script>
 
     <footer class="footer">
-      <p>&copy; Stuart Hicks 2016</p>
+      <p>&copy; Phil Cluff 2016</p>
     </footer>
 
   </div>

--- a/videojs-contrib-dash.html
+++ b/videojs-contrib-dash.html
@@ -57,7 +57,7 @@
 
     <div class="jumbotron">
       <p>This player is VideoJS with Contrib Dash (DashJS)<br><a href="http://videojs.github.io/videojs-contrib-dash/">More details can be found here.</a></p>
-      <p><small>VideoJS 5.2.1 ~ DashJS 1.5.1 ~ VideoJS Contrib Dash 2.0.0</small></p>
+      <p><small>VideoJS 5.9 ~ DashJS 1.2.0 ~ VideoJS Contrib Dash 2.4.0</small></p>
     </div>
 
     <script>

--- a/videojs-contrib-dash.html
+++ b/videojs-contrib-dash.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>Phil's Players - VideoJS with Contrib Dash (DashJS)</title>
+  <title>Stuart's Players - VideoJS with Contrib Dash (DashJS)</title>
 
   <!-- Bootstrap -->
   <link href="css/bootstrap.min.css" rel="stylesheet">
@@ -13,11 +13,10 @@
   <link href="css/jumbotron-narrow.css" rel="stylesheet">
 
   <!-- VideoJS, DashJS -->
-  <script src="js/video.js"></script>
-  <script src="js/dash.all.js"></script>
-  <script src="js/videojs-dash.min.js"></script>
-  <link rel="stylesheet"href="css/video-js.min.css" ></link>
-  <link rel="stylesheet" type="text/css" href="css/videojs-contrib-dash.css"></link>
+  <script src="//vjs.zencdn.net/5.9/video.js"></script>
+  <script src="//cdn.dashjs.org/latest/dash.all.debug.js"></script>
+  <script src="https://npmcdn.com/videojs-contrib-dash@^2.4.0/dist/videojs-dash.js"></script>
+  <link href="//vjs.zencdn.net/5.9/video-js.css" rel="stylesheet">
 
   <!-- JQuery -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
@@ -34,7 +33,7 @@
           <li role="presentation"><a href="#">Contact</a></li>
         </ul>
       </nav>
-      <h3 class="text-muted">Phil's Players</h3>
+      <h3 class="text-muted">Stuart's Players</h3>
     </div>
 
     <div class="jumbotron">
@@ -104,7 +103,7 @@
     </script>
 
     <footer class="footer">
-      <p>&copy; Phil Cluff 2016</p>
+      <p>&copy; Stuart Hicks 2016</p>
     </footer>
 
   </div>


### PR DESCRIPTION
Updated to a Brightcove player at the latest default version, configured to auto-update. Also updated VideooJS (contrib DASH) player to latest version.

Notably the Brightcove player now requires the license url to be set explicitly, and is no longer parsed out of the manifest (regardless of what the docs say).