### PR TITLE
added functionality to pass in manifests dynamically

### DIFF
--- a/bc-player-hls.html
+++ b/bc-player-hls.html
@@ -13,14 +13,22 @@
   <link href="css/ie10-viewport-bug-workaround.css" rel="stylesheet">
   <link href="css/jumbotron-narrow.css" rel="stylesheet">
 
-  <!-- Style Switcher -->
-  <script src="js/docs-themes.js" type="text/javascript"></script>
-  <script type="text/javascript">set_style();</script>
-
   <link rel="stylesheet" type="text/css" href="css/videojs-contrib-dash.css"></link>
 
   <!--  JQuery -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+
+  <!-- Style Switcher & custom js -->
+  <script src="js/docs-themes.js" type="text/javascript"></script>
+  <script>
+    $(document).ready(function(){
+      // set style
+      set_style();
+
+      // insert hls and dash manifests if passed via GET
+      insertManifestsFromGet();
+    });
+  </script>
 
 </head>
 
@@ -42,7 +50,7 @@
       <form id="playform">
         <div class="form-group">
           <label for="manifest">HLS Manifest:</label>
-          <input type="text" class="form-control" id="manifest" name="manifest">
+          <input type="text" class="form-control" id="hls-manifest" name="manifest">
         </div>
         <button type="submit" class="btn btn-primary btn-lg">Play!</button><br><br>
         <button type="button" id="demo" class="btn btn-info btn-sm">Load Demo Manifest</button>
@@ -64,7 +72,7 @@
     $( "#playform" ).submit(function( event ) {
 
       player.src({
-        src: $( "#manifest" ).val(),
+        src: $( "#hls-manifest" ).val(),
         type: 'application/vnd.apple.mpegurl'
       });
 
@@ -73,7 +81,7 @@
     });
 
     $( "#demo" ).click(function() {
-      $( "#manifest" ).val("https://d1czxfd0hfd9km.cloudfront.net/outputs/bbb/mediaconvert/hls/bbb.m3u8");
+      $( "#hls-manifest").val("https://d1czxfd0hfd9km.cloudfront.net/outputs/bbb/mediaconvert/hls/bbb.m3u8");
       $( "#playform" ).submit();
     });
     </script>

--- a/bc-player.html
+++ b/bc-player.html
@@ -13,12 +13,22 @@
   <link href="css/ie10-viewport-bug-workaround.css" rel="stylesheet">
   <link href="css/jumbotron-narrow.css" rel="stylesheet">
 
-  <!-- Style Switcher -->
-  <script src="js/docs-themes.js" type="text/javascript"></script>
-  <script type="text/javascript">set_style();</script>
+
 
   <!--  JQuery -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+ 
+  <!-- Style Switcher & custom js -->
+  <script src="js/docs-themes.js" type="text/javascript"></script>
+  <script>
+    $(document).ready(function(){
+      // set style
+      set_style();
+
+      // insert hls and dash manifests if passed via GET
+      insertManifestsFromGet();
+    });
+  </script>
 
 </head>
 
@@ -40,7 +50,7 @@
       <form id="playform">
         <div class="form-group">
           <label for="manifest">MPEG DASH Manifest:</label>
-          <input type="text" class="form-control" id="manifest" name="manifest">
+          <input type="text" class="form-control" id="dash-manifest" name="manifest">
         </div>
         <div class="form-group">
           <label for="license">Widevine License Server: <small>(Optional)</small></label>

--- a/bitmovin-player.html
+++ b/bitmovin-player.html
@@ -13,15 +13,23 @@
   <link href="css/ie10-viewport-bug-workaround.css" rel="stylesheet">
   <link href="css/jumbotron-narrow.css" rel="stylesheet">
 
-  <!-- Style Switcher -->
-  <script src="js/docs-themes.js" type="text/javascript"></script>
-  <script type="text/javascript">set_style();</script>
-
   <!-- Bitmovin -->
   <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8.2.1/bitmovinplayer.js"></script>
 
   <!-- JQuery -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+
+  <!-- Style Switcher & custom js -->
+  <script src="js/docs-themes.js" type="text/javascript"></script>
+  <script>
+    $(document).ready(function(){
+      // set style
+      set_style();
+
+      // insert hls and dash manifests if passed via GET
+      insertManifestsFromGet();
+    });
+  </script>
 
 </head>
 
@@ -100,6 +108,7 @@
       $( "#dash-manifest" ).val("https://d1czxfd0hfd9km.cloudfront.net/outputs/bbb/mediaconvert/dash/bbb.mpd");
       $( "#dash-button" ).trigger( "click" );
     });
+
     </script>
 
     <footer class="footer">

--- a/dashjs.html
+++ b/dashjs.html
@@ -13,15 +13,23 @@
   <link href="css/ie10-viewport-bug-workaround.css" rel="stylesheet">
   <link href="css/jumbotron-narrow.css" rel="stylesheet">
 
-  <!-- Style Switcher -->
-  <script src="js/docs-themes.js" type="text/javascript"></script>
-  <script type="text/javascript">set_style();</script>
-
   <!-- DashJS Latest -->
   <script src="https://cdn.dashjs.org/latest/dash.all.min.js"></script>
 
   <!-- JQuery -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+
+  <!-- Style Switcher & custom js -->
+  <script src="js/docs-themes.js" type="text/javascript"></script>
+  <script>
+    $(document).ready(function(){
+      // set style
+      set_style();
+
+      // insert hls and dash manifests if passed via GET
+      insertManifestsFromGet();
+    });
+  </script>
 
 </head>
 
@@ -43,7 +51,7 @@
       <form id="playform">
         <div class="form-group">
           <label for="manifest">MPEG DASH Manifest:</label>
-          <input type="text" class="form-control" id="manifest" name="manifest">
+          <input type="text" class="form-control" id="dash-manifest" name="manifest">
         </div>
         <button type="button" id="play-button" class="btn btn-primary btn-lg">Play!</button><br><br>
         <button type="button" id="demo-button" class="btn btn-info btn-sm">Load Demo Manifest</button>

--- a/fairplay.html
+++ b/fairplay.html
@@ -13,14 +13,22 @@
   <link href="css/ie10-viewport-bug-workaround.css" rel="stylesheet">
   <link href="css/jumbotron-narrow.css" rel="stylesheet">
 
-  <!-- Style Switcher -->
-  <script src="js/docs-themes.js" type="text/javascript"></script>
-  <script type="text/javascript">set_style();</script>
-
   <link rel="stylesheet" type="text/css" href="css/videojs-contrib-dash.css"></link>
 
   <!--  JQuery -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+
+  <!-- Style Switcher & custom js -->
+  <script src="js/docs-themes.js" type="text/javascript"></script>
+  <script>
+    $(document).ready(function(){
+      // set style
+      set_style();
+
+      // insert hls and dash manifests if passed via GET
+      insertManifestsFromGet();
+    });
+  </script>
 
 </head>
 
@@ -42,7 +50,7 @@
       <form id="playform">
         <div class="form-group">
           <label for="manifest">HLS Manifest:</label>
-          <input type="text" class="form-control" id="manifest" name="manifest">
+          <input type="text" class="form-control" id="hls-manifest" name="manifest">
           <label for="license">Fairplay License:</label>
           <input type="text" class="form-control" id="license" name="license">
           <label for="certificate">Fairplay Certificate:</label>
@@ -72,7 +80,7 @@
           {
             "ext_x_version": "5",
             "type": "application/x-mpegURL",
-            "src": $( "#manifest" ).val(),
+            "src": $( "#hls-manifest" ).val(),
             "key_systems": {
               "com.apple.fps.1_0": {
                 "certificate_url": $( "#certificate" ).val(),

--- a/hls-js.html
+++ b/hls-js.html
@@ -13,15 +13,23 @@
   <link href="css/ie10-viewport-bug-workaround.css" rel="stylesheet">
   <link href="css/jumbotron-narrow.css" rel="stylesheet">
 
-  <!-- Style Switcher -->
-  <script src="js/docs-themes.js" type="text/javascript"></script>
-  <script type="text/javascript">set_style();</script>
-
   <!-- HLS.js -->
   <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
 
   <!-- JQuery -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+
+  <!-- Style Switcher & custom js -->
+  <script src="js/docs-themes.js" type="text/javascript"></script>
+  <script>
+    $(document).ready(function(){
+      // set style
+      set_style();
+
+      // insert hls and dash manifests if passed via GET
+      insertManifestsFromGet();
+    });
+  </script>
 
 </head>
 
@@ -43,7 +51,7 @@
       <form id="playform">
         <div class="form-group">
           <label for="manifest">HLS Manifest:</label>
-          <input type="text" class="form-control" id="manifest" name="manifest"><br>
+          <input type="text" class="form-control" id="hls-manifest" name="manifest"><br>
           <button id="hls-button" type="submit" class="btn btn-primary btn-lg">Play HLS!</button><br><br>
         </div>
 
@@ -65,7 +73,7 @@
     $( "#hls-button" ).click(function( event ) {
       var video = document.getElementById('example');
       var hls = new Hls();
-      hls.loadSource($( "#manifest" ).val());
+      hls.loadSource($( "#hls-manifest" ).val());
       hls.attachMedia(video);
       hls.on(Hls.Events.MANIFEST_PARSED,function() {
         video.play();
@@ -74,7 +82,7 @@
     });
 
     $( "#demo" ).click(function( event ) {
-      $( "#manifest" ).val("https://d1czxfd0hfd9km.cloudfront.net/outputs/bbb/mediaconvert/hls/bbb.m3u8");
+      $( "#hls-manifest" ).val("https://d1czxfd0hfd9km.cloudfront.net/outputs/bbb/mediaconvert/hls/bbb.m3u8");
       $( "#hls-button" ).trigger( "click" );
       event.preventDefault();
     });

--- a/index.html
+++ b/index.html
@@ -1,80 +1,110 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Phil's Players - Select a player</title>
+    <!-- Bootstrap -->
+    <link href="css/bootstrap.flatly.min.css" title="default" rel="stylesheet">
+    <link href="css/bootstrap.darkly.min.css" title="dark" rel="stylesheet">
+    <link href="css/ie10-viewport-bug-workaround.css" rel="stylesheet">
+    <link href="css/jumbotron-narrow.css" rel="stylesheet">
+    <style>
+        .form-check-input {
+      float:right;
+    }
+  </style>
+    <!-- JQuery -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+    <!-- Style Switcher & custom js -->
+    <script src="js/docs-themes.js" type="text/javascript"></script>
+    <script>
+        $(document).ready(function(){
+      // set style
+      set_style();
 
-  <title>Phil's Players - Select a player</title>
-
-  <!-- Bootstrap -->
-  <link href="css/bootstrap.flatly.min.css" title="default" rel="stylesheet">
-  <link href="css/bootstrap.darkly.min.css" title="dark" rel="stylesheet">
-  <link href="css/ie10-viewport-bug-workaround.css" rel="stylesheet">
-  <link href="css/jumbotron-narrow.css" rel="stylesheet">
-
-  <!-- Style Switcher -->
-  <script src="js/docs-themes.js" type="text/javascript"></script>
-  <script type="text/javascript">set_style();</script>
+      // insert hls and dash manifests if passed via GET
+      insertManifestsFromGet();
+      var checked = false;
+        $('#check-button').click(function (event) {
+          event.preventDefault();
+          if (!checked) {
+              $("input[type='checkbox']").each(function () { //loop through each checkbox
+                  $(this).prop('checked', true); //check 
+              });
+              checked = true;;
+          } else {
+              $("input[type='checkbox']").each(function () { //loop through each checkbox
+                  $(this).prop('checked', false); //uncheck              
+              });
+              checked = false;
+          }
+        });
+    });
+  </script>
 </head>
 
 <body>
-  <div class="container">
-    <div class="header clearfix">
-      <nav>
-        <ul class="nav nav-pills pull-right">
-          <li role="presentation" class="active"><a href="index.html">Select a Player</a></li>
-          <li role="presentation"><a href="#" onclick='switch_style("dark"); return false;'>Dark</a></li>
-          <li role="presentation"><a href="#" onclick='switch_style("default"); return false;'>Light</a></li>
-        </ul>
-      </nav>
-      <h3 class="text-muted">Phil's Players</h3>
+    <div class="container">
+        <div class="header clearfix">
+            <nav>
+                <ul class="nav nav-pills pull-right">
+                    <li role="presentation" class="active"><a href="index.html">Select a Player</a></li>
+                    <li role="presentation"><a href="#" onclick='switch_style("dark"); return false;'>Dark</a></li>
+                    <li role="presentation"><a href="#" onclick='switch_style("default"); return false;'>Light</a></li>
+                </ul>
+            </nav>
+            <h3 class="text-muted">Phil's Players</h3>
+        </div>
+        <div class="jumbotron">
+            <h1>Phil's Players</h1>
+            <p>A set of video players where you can bring your own HLS or DASH manifest URL for a quick test.</p>
+            <h2>Open Source players</h2>
+            <ul>
+                <li class="list-group-item"><a href="dashjs.html">DashJS (DASH)</a>
+                    <input type="checkbox" class="form-check-input" data-url="dashjs.html">
+                </li>
+                <li class="list-group-item"><a href="hls-js.html">HLS.js (HLS)</a><input type="checkbox" class="form-check-input" </li> <li class="list-group-item"><a href="shaka-player.html">Shaka Player (DASH)</a><input type="checkbox" class="form-check-input" </li> <li class="list-group-item"><a href="videojs-7-vhs.html">VideoJS 7 with VHS (HLS or DASH)</a><input type="checkbox" class=""> or <a href="videojs-7-vhs-with-mux.html">with Mux Data</a><input type="checkbox" class=""></li>
+            </ul>
+            <h2>Commercial players</h2>
+            <ul>
+                <li class="list-group-item"><a href="bitmovin-player.html">Bitmovin Player (HLS or DASH)</a><input type="checkbox" class="form-check-input"></li>
+                <li class="list-group-item"><a href="bc-player.html">Brightcove Player (DASH CENC with Silverlight fallback)</a><input type="checkbox" class="form-check-input"></li>
+                <li class="list-group-item"><a href="bc-player-hls.html">Brightcove Player (HLS)</a><input type="checkbox" class="form-check-input"></li>
+                <li class="list-group-item"><a href="fairplay.html">Brightcove Player (HLS with Fairplay)</a><input type="checkbox" class="form-check-input"></li>
+                <li class="list-group-item"><a href="jwplayer.html">JWPlayer (HLS or DASH)</a><input type="checkbox" class="form-check-input"></li>
+                <li class="list-group-item"><a href="theoplayer.html">THEOplayer (HLS or DASH)</a><input type="checkbox" class="form-check-input"></li>
+                <li class="list-group-item"><a href="wowza-player.html">Wowza Player (HLS)</a><input type="checkbox" class="form-check-input"></li>
+            </ul>
+            <div class="jumbotron">
+                <div class="form-group">
+                    <label for="hls-manifest">HLS Manifest:</label>
+                    <input type="text" class="form-control" id="hls-manifest" name="hls-manifest"><br>
+                    <label for="dash-manifest">DASH Manifest:</label>
+                    <input type="text" class="form-control" id="dash-manifest" name="dash-manifest"><br>
+                    <button id="launch-button" type="button" onclick="launchPlayers()" class="btn btn-primary btn-lg">Launch Checked Players</button><button id="check-button" type="button" onclick="return false;" class="btn btn-primary btn-lg">Check/Un-Check All</button><br><br>
+                </div>
+            </div>
+            <h2>Legacy players</h2>
+            <p><small>These players are old, but remain because some people still have old links to them. Eventually we'll remove these and redirect you to the latest version.</small></p>
+            <ul>
+                <li class="list-group-item"><a href="videojs-contrib-hls.html">VideoJS 5 with contrib-hls (HLS)</a></li>
+                <li class="list-group-item"><a href="videojs-contrib-dash.html">VideoJS 5 with contrib-dash (DASH) (With Widevine and Chromecast)</a></li>
+            </ul>
+        </div>
+        <div class="jumbotron">
+            <h2>Tell me more...</h2>
+            <p>Video player demo websites rarely let you test their player with your media.</p>
+            <p>This site lets you select a player, enter a HLS or DASH manifest URL, and hit play!</p>
+            <p><a href="https://github.com/GeneticGenesis/phils-players">Code's on Github!</a></p>
+        </div>
+        <footer class="footer">
+            <p>&copy; Phil Cluff &amp; <a href="https://github.com/GeneticGenesis/phils-players#authors"> The Authors</a> 2019.</p>
+        </footer>
     </div>
-
-    <div class="jumbotron">
-      <h1>Phil's Players</h1>
-      <p>A set of video players where you can bring your own HLS or DASH manifest URL for a quick test.</p>
-
-      <h2>Open Source players</h2>
-      <ul>
-        <li class="list-group-item"><a href="dashjs.html" >DashJS (DASH)</a></li>
-        <li class="list-group-item"><a href="hls-js.html" >HLS.js (HLS)</a></li>
-        <li class="list-group-item"><a href="shaka-player.html" >Shaka Player (DASH)</a></li>
-        <li class="list-group-item"><a href="videojs-7-vhs.html" >VideoJS 7 with VHS (HLS or DASH)</a> or <a href="videojs-7-vhs-with-mux.html" >with Mux Data</a></li>
-      </ul>
-
-      <h2>Commercial players</h2>
-      <ul>
-        <li class="list-group-item"><a href="bitmovin-player.html" >Bitmovin Player (HLS or DASH)</a></li>
-        <li class="list-group-item"><a href="bc-player.html" >Brightcove Player (DASH CENC with Silverlight fallback)</a></li>
-        <li class="list-group-item"><a href="bc-player-hls.html" >Brightcove Player (HLS)</a></li>
-        <li class="list-group-item"><a href="fairplay.html" >Brightcove Player (HLS with Fairplay)</a></li>
-        <li class="list-group-item"><a href="jwplayer.html" >JWPlayer (HLS or DASH)</a></li>
-        <li class="list-group-item"><a href="theoplayer.html" >THEOplayer (HLS or DASH)</a></li>  
-        <li class="list-group-item"><a href="wowza-player.html" >Wowza Player (HLS)</a></li>
-      </ul>
-
-      <h2>Legacy players</h2>
-      <p><small>These players are old, but remain because some people still have old links to them. Eventually we'll remove these and redirect you to the latest version.</small></p>
-      <ul>
-        <li class="list-group-item"><a href="videojs-contrib-hls.html" >VideoJS 5 with contrib-hls (HLS)</a></li>
-        <li class="list-group-item"><a href="videojs-contrib-dash.html" >VideoJS 5 with contrib-dash (DASH) (With Widevine and Chromecast)</a></li>
-      </ul>
-    </div>
-
-    <div class="jumbotron">
-      <h2>Tell me more...</h2>
-      <p>Video player demo websites rarely let you test their player with your media.</p>
-      <p>This site lets you select a player, enter a HLS or DASH manifest URL, and hit play!</p>
-      <p><a href="https://github.com/GeneticGenesis/phils-players">Code's on Github!</a></p>
-    </div>
-
-    <footer class="footer">
-      <p>&copy; Phil Cluff &amp; <a href="https://github.com/GeneticGenesis/phils-players#authors"> The Authors</a> 2019.</p>
-    </footer>
-
-  </div>
-
-  <script src="js/ie10-viewport-bug-workaround.js"></script>
+    <script src="js/ie10-viewport-bug-workaround.js"></script>
 </body>
+
 </html>

--- a/js/docs-themes.js
+++ b/js/docs-themes.js
@@ -1,88 +1,111 @@
-
-var theme_name = "phils-player-theme" ;
+var theme_name = "phils-player-theme";
 
 function switch_style(css_title) {
-  var i, link_tag ;
-  for (i = 0, link_tag = document.getElementsByTagName("link") ;
-    i < link_tag.length ; i++ ) {
-    if ((link_tag[i].rel.indexOf("stylesheet") != -1) && link_tag[i].title) {
-      link_tag[i].disabled = true ;
-      if (link_tag[i].title == css_title) {
-        link_tag[i].disabled = false ;
-      }
+    var i, link_tag;
+    for (i = 0, link_tag = document.getElementsByTagName("link"); i < link_tag.length; i++) {
+        if ((link_tag[i].rel.indexOf("stylesheet") != -1) && link_tag[i].title) {
+            link_tag[i].disabled = true;
+            if (link_tag[i].title == css_title) {
+                link_tag[i].disabled = false;
+            }
+        }
+        localStorage.setItem(theme_name, css_title);
     }
-    localStorage.setItem(theme_name, css_title);
-  }
 }
 
 function set_style() {
-  var css_title = localStorage.getItem(theme_name)
-  // Set theme if it's a known theme, otherwise use default:
-  if (css_title == "default" || css_title == "dark") {
-    switch_style(css_title);
-  } else {
-    switch_style("default");
-  }
+    var css_title = localStorage.getItem(theme_name)
+    // Set theme if it's a known theme, otherwise use default:
+    if (css_title == "default" || css_title == "dark") {
+        switch_style(css_title);
+    } else {
+        switch_style("default");
+    }
 }
 
 // split the GET parameters
 function getURLParameter(param) {
-  var pageUrl = window.location.search.substring(1);
-  var urlVars = pageUrl.split('&');
+    var pageUrl = window.location.search.substring(1);
+    var urlVars = pageUrl.split('&');
 
-  // iterate over the parameters, and try to match
-  for (var i = 0; i < urlVars.length; i++) {
-    var paramName = urlVars[i].split('=');
+    // iterate over the parameters, and try to match
+    for (var i = 0; i < urlVars.length; i++) {
+        var paramName = urlVars[i].split('=');
 
-    // if match (case insensitive), return it or false
-    if (paramName[0].toLowerCase() == param.toLowerCase()) {
-      return paramName[1];
+        // if match (case insensitive), return it or false
+        if (paramName[0].toLowerCase() == param.toLowerCase()) {
+            return paramName[1];
+        }
     }
-  }
-  return false;
+    return false;
 }
 
 // for when there is a single manifest
-function insertSelectedManifest(kind){
-  if (kind == "hls") {
-    if (getURLParameter("hls")){
-      $("#manifest").val(getURLParameter("hls"));
-      $("#hls-button").trigger( "click" );
+function insertSelectedManifest(kind) {
+    if (kind == "hls") {
+        if (getURLParameter("hls")) {
+            $("#manifest").val(getURLParameter("hls"));
+            $("#hls-button").trigger("click");
+        }
     }
-  }
 
-  if (kind == "dash") {
-    if (getURLParameter("dash")){
-      $("#manifest").val(getURLParameter("dash"));
-      $("#dash-button").trigger( "click" );
+    if (kind == "dash") {
+        if (getURLParameter("dash")) {
+            $("#manifest").val(getURLParameter("dash"));
+            $("#dash-button").trigger("click");
+        }
     }
-  }
 }
 
 // if there is a GET parameter for hls or dash, insert them into the input fields
-function insertManifestsFromGet(){
+function insertManifestsFromGet() {
 
-  // hls
-  if (getURLParameter("hls")){
-    $("#hls-manifest").val(getURLParameter("hls"));
+    // hls
+    if (getURLParameter("hls")) {
+        $("#hls-manifest").val(getURLParameter("hls"));
+    }
+
+    // dash
+    if (getURLParameter("dash")) {
+        $("#dash-manifest").val(getURLParameter("dash"));
+    }
+
+    // insert buttons for custom behavior if only single #manifest
+    if ($("#manifest").length == 1) {
+        if (getURLParameter("hls")) {
+            $(".form-group").append('<button type="button" onclick="insertSelectedManifest(\'hls\')" id="hls-get" class="btn btn-info btn-sm">Load your GET HLS Manifest</button>');
+        }
+
+        if (getURLParameter("dash")) {
+            $(".form-group").append('<button type="button" onclick="insertSelectedManifest(\'dash\')" id="dash-get" class="btn btn-info btn-sm">Load your GET DASH Manifest</button>');
+        }
+
+    }
+}
+
+
+function launchPlayers(){
+  
+  let popupAlert = false;
+
+  // get all checked boxes and find the sibling's url
+  let checked = $("input[type='checkbox']:checked").prev().toArray();
+  let allPlayers = [];
+
+  // add to array
+  for (c in checked) {
+    allPlayers.push(checked[c].href);
   }
 
-  // dash
-  if (getURLParameter("dash")){
-    $("#dash-manifest").val(getURLParameter("dash"));
-  }
 
-  // insert buttons for custom behavior if only single #manifest
-  if ($("#manifest").length == 1)
-  {
-      if (getURLParameter("hls")) {
-        $(".form-group").append('<button type="button" onclick="insertSelectedManifest(\'hls\')" id="hls-get" class="btn btn-info btn-sm">Load your GET HLS Manifest</button>');
+  // open each player in a new tab
+  for (var p in allPlayers) {
+    let w = window.open(allPlayers[p] + "?hls=" + $("#hls-manifest").val() + "&dash=" + $("#dash-manifest").val())
+    if (w == null || typeof(popUp)=='undefined') {
+      if (!popupAlert){
+        alert("This page opens a page for every selected player.  Your browser is blocking popups, please enable popups for this page to open all players!");
+        popupAlert = true;
       }
-
-      if (getURLParameter("dash")){
-        $(".form-group").append('<button type="button" onclick="insertSelectedManifest(\'dash\')" id="dash-get" class="btn btn-info btn-sm">Load your GET DASH Manifest</button>');
-      }
-      
+    }
   }
-    
-};
+}

--- a/js/docs-themes.js
+++ b/js/docs-themes.js
@@ -24,3 +24,65 @@ function set_style() {
     switch_style("default");
   }
 }
+
+// split the GET parameters
+function getURLParameter(param) {
+  var pageUrl = window.location.search.substring(1);
+  var urlVars = pageUrl.split('&');
+
+  // iterate over the parameters, and try to match
+  for (var i = 0; i < urlVars.length; i++) {
+    var paramName = urlVars[i].split('=');
+
+    // if match (case insensitive), return it or false
+    if (paramName[0].toLowerCase() == param.toLowerCase()) {
+      return paramName[1];
+    }
+  }
+  return false;
+}
+
+// for when there is a single manifest
+function insertSelectedManifest(kind){
+  if (kind == "hls") {
+    if (getURLParameter("hls")){
+      $("#manifest").val(getURLParameter("hls"));
+      $("#hls-button").trigger( "click" );
+    }
+  }
+
+  if (kind == "dash") {
+    if (getURLParameter("dash")){
+      $("#manifest").val(getURLParameter("dash"));
+      $("#dash-button").trigger( "click" );
+    }
+  }
+}
+
+// if there is a GET parameter for hls or dash, insert them into the input fields
+function insertManifestsFromGet(){
+
+  // hls
+  if (getURLParameter("hls")){
+    $("#hls-manifest").val(getURLParameter("hls"));
+  }
+
+  // dash
+  if (getURLParameter("dash")){
+    $("#dash-manifest").val(getURLParameter("dash"));
+  }
+
+  // insert buttons for custom behavior if only single #manifest
+  if ($("#manifest").length == 1)
+  {
+      if (getURLParameter("hls")) {
+        $(".form-group").append('<button type="button" onclick="insertSelectedManifest(\'hls\')" id="hls-get" class="btn btn-info btn-sm">Load your GET HLS Manifest</button>');
+      }
+
+      if (getURLParameter("dash")){
+        $(".form-group").append('<button type="button" onclick="insertSelectedManifest(\'dash\')" id="dash-get" class="btn btn-info btn-sm">Load your GET DASH Manifest</button>');
+      }
+      
+  }
+    
+};

--- a/jwplayer.html
+++ b/jwplayer.html
@@ -13,15 +13,23 @@
   <link href="css/ie10-viewport-bug-workaround.css" rel="stylesheet">
   <link href="css/jumbotron-narrow.css" rel="stylesheet">
 
-  <!-- Style Switcher -->
-  <script src="js/docs-themes.js" type="text/javascript"></script>
-  <script type="text/javascript">set_style();</script>
-
   <!-- JWPlayer -->
   <script src="https://content.jwplatform.com/libraries/gGlYBoZy.js"> </script>
 
   <!-- JQuery -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+
+  <!-- Style Switcher & custom js -->
+  <script src="js/docs-themes.js" type="text/javascript"></script>
+  <script>
+    $(document).ready(function(){
+      // set style
+      set_style();
+
+      // insert hls and dash manifests if passed via GET
+      insertManifestsFromGet();
+    });
+  </script>
 
 </head>
 

--- a/shaka-player.html
+++ b/shaka-player.html
@@ -13,12 +13,20 @@
   <link href="css/ie10-viewport-bug-workaround.css" rel="stylesheet">
   <link href="css/jumbotron-narrow.css" rel="stylesheet">
 
-  <!-- Style Switcher -->
-  <script src="js/docs-themes.js" type="text/javascript"></script>
-  <script type="text/javascript">set_style();</script>
-
   <!--  JQuery -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+
+  <!-- Style Switcher & custom js -->
+  <script src="js/docs-themes.js" type="text/javascript"></script>
+  <script>
+    $(document).ready(function(){
+      // set style
+      set_style();
+
+      // insert hls and dash manifests if passed via GET
+      insertManifestsFromGet();
+    });
+  </script>
 
   <!--  Shaka Player -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/shaka-player/2.4.6/shaka-player.compiled.debug.externs.js"></script>

--- a/theoplayer.html
+++ b/theoplayer.html
@@ -13,15 +13,23 @@
   <link href="css/ie10-viewport-bug-workaround.css" rel="stylesheet">
   <link href="css/jumbotron-narrow.css" rel="stylesheet">
 
-  <!-- Style Switcher -->
-  <script src="js/docs-themes.js" type="text/javascript"></script>
-  <script type="text/javascript">set_style();</script>
-
   <!-- THEOplayer -->
   <link rel="stylesheet" type="text/css" href='https://cdn.myth.theoplayer.com/1dc4acdc-cf60-4483-ab3b-5fe38ada23c1/ui.css'>
 
   <!-- JQuery -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+
+  <!-- Style Switcher & custom js -->
+  <script src="js/docs-themes.js" type="text/javascript"></script>
+  <script>
+    $(document).ready(function(){
+      // set style
+      set_style();
+
+      // insert hls and dash manifests if passed via GET
+      insertManifestsFromGet();
+    });
+  </script>
 
 </head>
 

--- a/videojs-7-vhs-with-mux.html
+++ b/videojs-7-vhs-with-mux.html
@@ -13,10 +13,6 @@
   <link href="css/ie10-viewport-bug-workaround.css" rel="stylesheet">
   <link href="css/jumbotron-narrow.css" rel="stylesheet">
 
-  <!-- Style Switcher -->
-  <script src="js/docs-themes.js" type="text/javascript"></script>
-  <script type="text/javascript">set_style();</script>
-
   <!-- VideoJS -->
   <link href="//vjs.zencdn.net/7.4.1/video-js.min.css" rel="stylesheet">
   <script src="//vjs.zencdn.net/7.4.1/video.min.js"></script>
@@ -26,6 +22,18 @@
 
   <!-- JQuery -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+
+  <!-- Style Switcher & custom js -->
+  <script src="js/docs-themes.js" type="text/javascript"></script>
+  <script>
+    $(document).ready(function(){
+      // set style
+      set_style();
+
+      // insert hls and dash manifests if passed via GET
+      insertManifestsFromGet();
+    });
+  </script>
 
 </head>
 

--- a/videojs-7-vhs.html
+++ b/videojs-7-vhs.html
@@ -13,16 +13,24 @@
   <link href="css/ie10-viewport-bug-workaround.css" rel="stylesheet">
   <link href="css/jumbotron-narrow.css" rel="stylesheet">
 
-  <!-- Style Switcher -->
-  <script src="js/docs-themes.js" type="text/javascript"></script>
-  <script type="text/javascript">set_style();</script>
-
   <!-- VideoJS -->
   <link href="//vjs.zencdn.net/7.4.1/video-js.min.css" rel="stylesheet">
   <script src="//vjs.zencdn.net/7.4.1/video.min.js"></script>
 
   <!-- JQuery -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+
+  <!-- Style Switcher & custom js -->
+  <script src="js/docs-themes.js" type="text/javascript"></script>
+  <script>
+    $(document).ready(function(){
+      // set style
+      set_style();
+
+      // insert hls and dash manifests if passed via GET
+      insertManifestsFromGet();
+    });
+  </script>
 
 </head>
 

--- a/wowza-player.html
+++ b/wowza-player.html
@@ -13,15 +13,23 @@
   <link href="css/ie10-viewport-bug-workaround.css" rel="stylesheet">
   <link href="css/jumbotron-narrow.css" rel="stylesheet">
 
-  <!-- Style Switcher -->
-  <script src="js/docs-themes.js" type="text/javascript"></script>
-  <script type="text/javascript">set_style();</script>
-
   <!-- Wowza Player -->
   <script type="text/javascript" src="https://player.wowza.com/player/latest/wowzaplayer.min.js"></script>
 
   <!-- JQuery -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+
+  <!-- Style Switcher & custom js -->
+  <script src="js/docs-themes.js" type="text/javascript"></script>
+  <script>
+    $(document).ready(function(){
+      // set style
+      set_style();
+
+      // insert hls and dash manifests if passed via GET
+      insertManifestsFromGet();
+    });
+  </script>
 
 </head>
 
@@ -43,7 +51,7 @@
       <form id="playform">
         <div class="form-group">
           <label for="manifest">HLS Manifest:</label>
-          <input type="text" class="form-control" id="manifest" name="manifest"><br>
+          <input type="text" class="form-control" id="hls-manifest" name="manifest"><br>
           <button id="hls-button" type="button" class="btn btn-primary btn-lg">Play HLS!</button><br><br>
         </div>
 
@@ -66,14 +74,14 @@
       p = WowzaPlayer.create('playerElement',
           {
             "license":"PLAY2-d4cTb-DhMTP-tvdAD-9W48K-V664F",
-            "sourceURL": $( "#manifest" ).val(),
+            "sourceURL": $( "#hls-manifest" ).val(),
             "autoPlay": true	
           }
       );
     });
 
     $( "#demo" ).click(function( event ) {
-      $( "#manifest" ).val("https://d1czxfd0hfd9km.cloudfront.net/outputs/bbb/mediaconvert/hls/bbb.m3u8");
+      $( "#hls-manifest" ).val("https://d1czxfd0hfd9km.cloudfront.net/outputs/bbb/mediaconvert/hls/bbb.m3u8");
       $( "#hls-button" ).trigger( "click" );
     });
 


### PR DESCRIPTION
Added functionality to dynamically load manifests via GET parameters

example:
http://philcluff.co.uk/players/bitmovin-player.html?hls=http://foo/bar/myhls.m3u8&dash=http://foo/bar/mydash.mpd
will pre-populate the input fields

If only one input field exists, new buttons will be inserted for each (either dash or hls) manifest.

The intention is to launch a bunch of tests via script.