### PR TITLE
Always use latest Bitmovin Player

### DIFF
--- a/bitmovin-player.html
+++ b/bitmovin-player.html
@@ -18,7 +18,7 @@
   <script type="text/javascript">set_style();</script>
 
   <!-- Bitmovin -->
-  <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8.2.1/bitmovinplayer.js"></script>
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/bitmovin-player/bitmovinplayer.js"></script>
 
   <!-- JQuery -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>


### PR DESCRIPTION
The used Bitmovin Player version [8.2.1](https://developer.bitmovin.com/playback/docs/release-notes-web#v821) is almost 4 years old (Feb 2019). Upgrading to the latest.